### PR TITLE
prevent double tracking on first page load

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -114,7 +114,6 @@ export class Analytics {
 
 		window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 		ga('create', id, 'auto');
-		ga('send', 'pageview');
 
 		this._initialized = true;
 	}


### PR DESCRIPTION
ga('send', 'pageview') was called both in the init and in the _trackPage method, this caused on the first page load the event to be triggered twice.
